### PR TITLE
Add inventory item id

### DIFF
--- a/binda-shopify.gemspec
+++ b/binda-shopify.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'pg'
   s.add_dependency 'deface'
   s.add_development_dependency 'rspec-rails'
+  s.add_development_dependency 'pry-rails'
   s.add_development_dependency 'byebug'
   s.add_development_dependency 'shopify-mock'
   s.add_development_dependency 'database_cleaner'

--- a/lib/binda/shopify.rb
+++ b/lib/binda/shopify.rb
@@ -14,7 +14,8 @@ module Binda
       product: {
         'shopify-details' => {
           'handle' => 'handle',
-          'edit-product-url' => 'edit_url'
+          'edit-product-url' => 'edit_url',
+          'inventory-item-id' => ['variants', 'first', 'inventory_item_id']
         }
       },
       collection: {

--- a/lib/binda/shopify/importer.rb
+++ b/lib/binda/shopify/importer.rb
@@ -33,7 +33,12 @@ module Binda
                 if field_group
                   fields.each do |field_slug, method|
                     field_setting = field_group.field_settings.find_by(slug: "#{field_group_slug}-#{field_slug}")
-                    component.strings.find_by(field_setting_id: field_setting.id).update content: item.send(method) if field_setting
+                    if method.is_a? Array
+                      # https://stackoverflow.com/a/12065854/1498118
+                      component.strings.find_by(field_setting_id: field_setting.id).update content: method.inject(item, :send) if field_setting
+                    else
+                      component.strings.find_by(field_setting_id: field_setting.id).update content: item.send(method) if field_setting
+                    end
                   end
                 end
               end
@@ -78,6 +83,7 @@ module Binda
       def shop
         @shop ||= @client::Shop.current
       end
+
     end
   end
 end


### PR DESCRIPTION
Add inventory item id.

Coming from a previous version you need to manually add the corresponding `Binda::FieldSetting`.

```Ruby
Binda::FieldSetting.create({ 
    name: 'Inventory Item id',
    slug: 'shopify-product-shopify-details-inventory-item-id',
    field_group_id: Binda::FieldGroup.where(slug: 'shopify-product-shopify-details').ids,
    field_type: 'string'
})
```

For newly created app the field setting should be already there. (@Marchino: honestly I haven't checked it yet)